### PR TITLE
Full change

### DIFF
--- a/pg2kinesis/__main__.py
+++ b/pg2kinesis/__main__.py
@@ -29,7 +29,12 @@ def main(pg_dbname, pg_host, pg_port, pg_user, pg_slot_name,
     logger.info('Starting pg2kinesis')
 
     if full_change:
-        raise NotImplementedError
+        full_change_error_message = (
+            'Full Change is currently only supported with the "wal2json"'
+            ' pg-slot-output-plugin and the "JSONPayload" message-formatter'
+        )
+        assert pg_slot_output_plugin == 'wal2json' and message_formatter == 'JSONPayload', full_change_error_message
+
 
     logger.info('Getting kinesis stream writer')
     writer = StreamWriter(stream_name)

--- a/pg2kinesis/__main__.py
+++ b/pg2kinesis/__main__.py
@@ -14,6 +14,8 @@ from .log import logger
 @click.option('--pg-port', '-p', default='5432', help='Postgres port.')
 @click.option('--pg-user', '-u', help='Postgres user')
 @click.option('--pg-slot-name', '-s', default='pg2kinesis', help='Postgres replication slot name.')
+@click.option('--pg-slot-output-plugin', default='test_decoding',
+              help='Postgres replication slot output plugin')
 @click.option('--stream-name', '-k', default='pg2kinesis', help='Kinesis stream name.')
 @click.option('--message-formatter', '-f', default='CSVPayload', help='Kinesis record formatter.')
 @click.option('--table-pat', help='Optional regular expression for table names.')
@@ -21,8 +23,9 @@ from .log import logger
 @click.option('--create-slot', default=False, is_flag=True, help='Attempt to on start create a the slot.')
 @click.option('--recreate-slot', default=False, is_flag=True,
               help='Deletes the slot on start if it exists and then creates.')
-def main(pg_dbname, pg_host, pg_port, pg_user, pg_slot_name, stream_name,
-         message_formatter, table_pat, full_change, create_slot, recreate_slot):
+def main(pg_dbname, pg_host, pg_port, pg_user, pg_slot_name,
+         pg_slot_output_plugin, stream_name, message_formatter, table_pat,
+         full_change, create_slot, recreate_slot):
     logger.info('Starting pg2kinesis')
 
     if full_change:
@@ -31,7 +34,7 @@ def main(pg_dbname, pg_host, pg_port, pg_user, pg_slot_name, stream_name,
     logger.info('Getting kinesis stream writer')
     writer = StreamWriter(stream_name)
 
-    with SlotReader(pg_dbname, pg_host, pg_port, pg_user, pg_slot_name) as reader:
+    with SlotReader(pg_dbname, pg_host, pg_port, pg_user, pg_slot_name, pg_slot_output_plugin) as reader:
 
         if recreate_slot:
             reader.delete_slot()

--- a/pg2kinesis/slot.py
+++ b/pg2kinesis/slot.py
@@ -146,5 +146,9 @@ class SlotReader(object):
 
     def process_replication_stream(self, consume):
         logger.info('Starting the consumption of slot "%s"!' % self.slot_name)
-        self._repl_cursor.start_replication(self.slot_name)
+        if self.output_plugin == 'wal2json':
+            options = {'include-xids': 1}
+        else:
+            options = None
+        self._repl_cursor.start_replication(self.slot_name, options=options)
         self._repl_cursor.consume_stream(consume)

--- a/pg2kinesis/stream.py
+++ b/pg2kinesis/stream.py
@@ -33,8 +33,18 @@ class StreamWriter(object):
         agg_record = None
 
         if fmt_msg:
-            agg_record = self._record_agg.add_user_record(fmt_msg.change.xid, fmt_msg.fmt_msg)
+            if fmt_msg.is_bulk:
+                for change in fmt_msg.change.changes:
+                    agg_record = self._record_agg.add_user_record(fmt_msg.change.xid, fmt_msg.fmt_msg + change)
+                    agg_record = self._check_full_agg_record(agg_record)
+            else:
+                agg_record = self._record_agg.add_user_record(fmt_msg.change.xid, fmt_msg.fmt_msg)
 
+        agg_record = self._check_full_agg_record(agg_record)
+
+        return agg_record
+
+    def _check_full_agg_record(self, agg_record):
         # agg_record will be a complete record if aggregation is full.
         if agg_record or (self._send_window and time.time() - self.last_send > self._send_window):
             agg_record = agg_record if agg_record else self._record_agg.clear_and_get()

--- a/tests/test_slot.py
+++ b/tests/test_slot.py
@@ -9,7 +9,7 @@ from pg2kinesis.slot import SlotReader
 
 @pytest.fixture
 def slot():
-    slot = SlotReader('blah_db', 'blah_host', 'blah_port', 'blah_user', 'pg2kinesis', keepalive_window=0)
+    slot = SlotReader('blah_db', 'blah_host', 'blah_port', 'blah_user', 'pg2kinesis','test_decoding', keepalive_window=0)
     slot._repl_cursor = Mock()
     slot._repl_conn = Mock()
     slot._normal_conn = Mock()
@@ -206,6 +206,6 @@ def test_process_replication_stream(slot):
     consume = Mock()
     slot.process_replication_stream(consume)
 
-    assert call.start_replication('pg2kinesis') in  slot._repl_cursor.method_calls, 'We started replication event loop'
+    assert call.start_replication('pg2kinesis', options=None) in  slot._repl_cursor.method_calls, 'We started replication event loop'
     assert call.consume_stream(consume) in slot._repl_cursor.method_calls, 'We pass consume to this method'
 

--- a/tests/test_stream.py
+++ b/tests/test_stream.py
@@ -41,6 +41,7 @@ def test_put_message(writer):
     msg = Mock()
     msg.change.xid = 10
     msg.fmt_msg = object()
+    msg.is_bulk = False
 
     writer.last_send = 1445444940.0 - 10      # "2015-10-21 16:28:50"
     with freeze_time('2015-10-21 16:29:00'):  # -> 1445444940.0


### PR DESCRIPTION
- Adds support for specifying the logical replication output_plugin at the command line when starting pg2kinesis
- When using the 'wal2json' output_plugin, adds xid to the output
- Adds a JSONPayloadFormatter (for use with the wal2json output_pluging)
- Adds support for Full Change output (only with the JSONPayloadFormatter and wal2json output_plugin)

Notes:
The wal2json output_plugin already bulks the output of a transaction into a single JSON blob.

This broke one of the fundamental assumptions of the Formatter class. 

I tackled this by creating a BulkChange tuple that contains a list called 'changes' which contains string formatted changes for each change in the transaction.  

In the Stream writer, if the Message object has 'is_bulk' equals True, we assume that there are a list of changes to send instead of a single one.  We send each change with the fmt_msg (eg. '0,CDC,') appended on the front.

To ensure the agg_record doesn't get too full, we check if the agg_record is full after each change is added.  "put_message" will only return the last agg_record for checking if the messages have been sent.  Thus assuming that any previous agg_records that were sent during the iteration over the change list were successful.
